### PR TITLE
Fix a bunch of bugs on rundota.sh

### DIFF
--- a/rundota.sh
+++ b/rundota.sh
@@ -44,6 +44,12 @@ else  # PTS trace
     FLAGS="${FLAGS} +timedemo ${DOTA2_TRACE_FILE} +timedemo_start 50000 +timedemo_end 51000 -testscript_inline \"Test_WaitForCheckPoint DemoPlaybackFinished; quit\""
 fi
 
+demo_file_path="${DOTA2_DIR}/game/dota/${DOTA2_TRACE_FILE}.dem"
+if [ ! -e "$demo_file_path" ]; then
+	echo "demo file '$demo_file_path' not found"
+	exit 1
+fi
+
 # Make it work with APITrace
 #FLAGS="${FLAGS} -gl_disable_buffer_storage -gl_disable_compressed_texture_pixel_storage"
 

--- a/rundota.sh
+++ b/rundota.sh
@@ -54,7 +54,7 @@ fi
 #FLAGS="${FLAGS} -gl_disable_buffer_storage -gl_disable_compressed_texture_pixel_storage"
 
 # Start dota2 and set it to kill on shell exit
-for api in "gl vulkan"; do
+for api in gl vulkan; do
     for _ in `seq 1 5`; do
         "${DOTA2_BIN}" ${FLAGS} "-${api}"
         echo -n "${api}: "

--- a/rundota.sh
+++ b/rundota.sh
@@ -38,11 +38,16 @@ FLAGS="${FLAGS} +engine_no_focus_sleep 0"
 # Run the time demo and quit as soon as finished
 if [ $TRACE == "valve" ]; then
     DOTA2_TRACE_FILE=2203598540
-    FLAGS="${FLAGS} +timedemo ${DOTA2_TRACE_FILE} +timedemo_start 80000 +timedemo_end 85000 -testscript_inline \"Test_WaitForCheckPoint DemoPlaybackFinished; quit\""
+    trace_start_time=80000
+    trace_end_time=85000
 else  # PTS trace
     DOTA2_TRACE_FILE=1971360796
-    FLAGS="${FLAGS} +timedemo ${DOTA2_TRACE_FILE} +timedemo_start 50000 +timedemo_end 51000 -testscript_inline \"Test_WaitForCheckPoint DemoPlaybackFinished; quit\""
+    trace_start_time=50000
+    trace_end_time=51000
 fi
+FLAGS="${FLAGS} +timedemo ${DOTA2_TRACE_FILE}"
+FLAGS="${FLAGS} +timedemo_start ${trace_start_time} +timedemo_end ${trace_end_time}"
+FLAGS="${FLAGS} -testscript_inline \"Test_WaitForCheckPoint DemoPlaybackFinished; quit\""
 
 demo_file_path="${DOTA2_DIR}/game/dota/${DOTA2_TRACE_FILE}.dem"
 if [ ! -e "$demo_file_path" ]; then

--- a/rundota.sh
+++ b/rundota.sh
@@ -58,6 +58,6 @@ for api in gl vulkan; do
     for _ in `seq 1 5`; do
         "${DOTA2_BIN}" ${FLAGS} "-${api}"
         echo -n "${api}: "
-        tail -1 "${DOTA2_BENCH_CSV}" | awk '{print $2}' | tr -d ','
+        tail -2 "${DOTA2_BENCH_CSV}" | head -1 | awk '{print $2}' | tr -d ','
     done
 done

--- a/rundota.sh
+++ b/rundota.sh
@@ -17,7 +17,8 @@ export STEAM_RUNTIME=0
 
 # Force the use of two libraries that will either not be installed or will
 # conflict with system installed versions
-export LD_PRELOAD="${HOME}/.steam/ubuntu12_32/steam-runtime/amd64/lib/x86_64-linux-gnu/libudev.so.0 ${HOME}/.steam/ubuntu12_32/steam-runtime/amd64/lib/x86_64-linux-gnu/libpng12.so.0"
+preload_libs_dir="${HOME}/.steam/ubuntu12_32/steam-runtime/amd64/lib/x86_64-linux-gnu"
+export LD_PRELOAD="${preload_libs_dir}/libudev.so.0 ${preload_libs_dir}/libpng12.so.0"
 
 # Set the graphics to high
 FLAGS="${FLAGS} -autoconfig_level 3"

--- a/rundota.sh
+++ b/rundota.sh
@@ -17,7 +17,7 @@ export STEAM_RUNTIME=0
 
 # Force the use of two libraries that will either not be installed or will
 # conflict with system installed versions
-preload_libs_dir="${HOME}/.steam/ubuntu12_32/steam-runtime/amd64/lib/x86_64-linux-gnu"
+preload_libs_dir="${HOME}/.steam/bin32/steam-runtime/amd64/lib/x86_64-linux-gnu"
 export LD_PRELOAD="${preload_libs_dir}/libudev.so.0 ${preload_libs_dir}/libpng12.so.0"
 
 # Set the graphics to high

--- a/rundota.sh
+++ b/rundota.sh
@@ -32,6 +32,9 @@ FLAGS="${FLAGS} -fs -w 1920 -h 1080"
 # Show the framerate
 FLAGS="${FLAGS} +cl_showfps 2"
 
+# Don't run slower if we lose focus: this is a benchmark.
+FLAGS="${FLAGS} +engine_no_focus_sleep 0"
+
 # Run the time demo and quit as soon as finished
 if [ $TRACE == "valve" ]; then
     DOTA2_TRACE_FILE=2203598540


### PR DESCRIPTION
The first time I tried to automate benchmark runs for Dota2 someone referred me to this script. Over time I changed it significantly and now I run my own fork, but I figured I should contribute back the bug fixes in case the next person gets referred to this repository.

I also just noticed that some of my fixed were also implemented by https://github.com/rantogno/dota-bench/commit/d9824cdc3e87ad3643c3bb3d9d4c33f35a8231cf 

If you're interested in modifying this script further in a way where it only runs dota2 once (with $1 as -gl or -vulkan) I will contribute some more, possibly unifying my local fork with upstream.

Thanks for the script!